### PR TITLE
Change test runner.d to create all artifacts in 'bin' subfolder

### DIFF
--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -1,2 +1,3 @@
 /runner
 /cfg.dot
+/tmp

--- a/tests/runner.d
+++ b/tests/runner.d
@@ -23,6 +23,7 @@ version (linux) import core.sys.posix.unistd;
 
 immutable SDC = "../bin/sdc";
 immutable DMD = "dmd";
+immutable OUTPUT_DIRECTORY = "tmp";
 
 version (Windows) {
     immutable EXE_EXTENSION = ".exe";
@@ -30,6 +31,13 @@ version (Windows) {
     immutable EXE_EXTENSION = ".bin";
 }
 
+void createBinOutputDirectory()
+{
+    auto dir = OUTPUT_DIRECTORY;
+    if (!(exists(dir) && isDir(dir))) {
+        mkdir(dir);
+    }
+}
 
 string getTestFilename(int n)
 {
@@ -100,7 +108,7 @@ void test(string filename, string compiler)
     string cmdDeps = reduce!((string deps, string dep){ return format(`%s"%s" `, deps, dep); })("", dependencies);
     version (Windows) string exeName;
     else string exeName = "./";
-    exeName ~= filename ~ EXE_EXTENSION;
+    exeName ~= OUTPUT_DIRECTORY ~ "/" ~ filename ~ EXE_EXTENSION;
     if (file.exists(exeName)) {
         file.remove(exeName);
     }
@@ -159,6 +167,9 @@ int main(string[] args)
             "only-failed", &displayOnlyFailed,
             "wait-on-exit", &waitOnExit,
             "help", delegate {usage(); exit(0);});
+
+    createBinOutputDirectory();
+
     if (args.length > 1) {
         int testNumber = to!int(args[1]);
         auto testName = getTestFilename(testNumber);


### PR DESCRIPTION
This PR modifies runner.d such that all artifacts are created in a `bin` subfolder.

Currently
`cd tests`
`./runner.d`
creates all artifacts in the tests directory. Personally, I find this very annoying as it clobbers up the test source file directory, making it more tedious to list/open a testfile in an editor.

(SDC will still create the objfile in the wrong folder, see issue #166)