### PR TITLE
Strip path+ext from input filename for objfilename & execfilename

### DIFF
--- a/sdc/src/sdc/main.d
+++ b/sdc/src/sdc/main.d
@@ -13,7 +13,6 @@ import sdc.terminal;
 
 import std.array;
 import std.getopt;
-import std.path;
 
 int main(string[] args) {
 	version(DigitalMars) {
@@ -62,6 +61,8 @@ int main(string[] args) {
 	
 	auto files = args[1 .. $];
 	
+	// Generate filenames for output artifacts (if not specified on commandline)
+	import std.path : baseName, stripExtension;
 	auto stripped_filename = baseName(stripExtension(files[0]));
 	auto executable = stripped_filename;
 	version(Windows) executable ~= ".exe";

--- a/sdc/src/sdc/main.d
+++ b/sdc/src/sdc/main.d
@@ -13,6 +13,7 @@ import sdc.terminal;
 
 import std.array;
 import std.getopt;
+import std.path;
 
 int main(string[] args) {
 	version(DigitalMars) {
@@ -61,8 +62,10 @@ int main(string[] args) {
 	
 	auto files = args[1 .. $];
 	
-	auto executable = "a.out";
-	auto objFile = files[0][0 .. $-2] ~ ".o";
+	auto stripped_filename = baseName(stripExtension(files[0]));
+	auto executable = stripped_filename;
+	version(Windows) executable ~= ".exe";
+	auto objFile = stripped_filename ~ ".o";
 	if (outputFile.length) {
 		if (dontLink) {
 			objFile = outputFile;


### PR DESCRIPTION
When running the command
`sdc ../test.d`
*before* this PR: creates `../test.o` and `a.out`(executable)
*after* this PR:    creates `test.o` and `test`(executable) both in the current folder (DMD behavior)

This PR fixes #166.