### PR TITLE
Fix callOverloadSet (for real now)

### DIFF
--- a/libd/src/d/semantic/expression.d
+++ b/libd/src/d/semantic/expression.d
@@ -765,7 +765,13 @@ public:
 		import std.algorithm, std.array;
 		return callCallable(location, chooseOverload(location, s.set.map!((s) {
 			if (auto f = cast(Function) s) {
-				return getFrom(location, f);
+				auto c = getFrom(location, f);
+				if (c.type.kind != TypeKind.Error) {
+					return c;
+				} else {
+					//try to call as regular Function
+					return build!FunctionExpression(f.location, f);
+				}
 			} else if (auto t = cast(Template) s) {
 				return handleIFTI(location, t, args);
 			}


### PR DESCRIPTION
in cases like opEqual overloads
we find ourselves in a siltation where we have a method that is part of a struct/class
but must be called as a regular function.
this PR sloves this.
 