### PR TITLE
This is patch for issue no 192 'no error on missing default in non-final switches'

### DIFF
--- a/libd/src/d/semantic/flow.d
+++ b/libd/src/d/semantic/flow.d
@@ -34,7 +34,8 @@ private:
 		bool, "allowFallthrough", 1,
 		bool, "switchMustTerminate", 1,
 		bool, "switchFunTerminate", 1,
-		uint, "", 2,
+		bool, "switchHaveDefault", 1,
+		uint, "", 1,
 	));
 	
 public:
@@ -196,6 +197,7 @@ public:
 		auto oldSwitchMustTerminate = switchMustTerminate;
 		auto oldSwitchFunTerminate = switchFunTerminate;
 		auto oldBlockTerminate = blockTerminate;
+		auto oldSwitchHaveDefault = switchHaveDefault;
 		
 		scope(exit) {
 			mustTerminate = switchMustTerminate && mustTerminate;
@@ -207,14 +209,23 @@ public:
 			allowFallthrough = oldAllowFallthrough;
 			switchMustTerminate = oldSwitchMustTerminate;
 			switchFunTerminate = oldSwitchFunTerminate;
+			switchHaveDefault = oldSwitchHaveDefault;
 		}
 		
 		switchStmt = s;
 		switchStack = varStack;
 		allowFallthrough = true;
 		switchFunTerminate = true;
-		
+		switchHaveDefault = false;
 		visit(s.statement);
+
+		if (!switchHaveDefault) {
+			import d.exception;
+			throw new CompileException(
+				s.location,
+				"switch statement without a default; use 'final switch' or add 'default: assert(0);' or add 'default: break;'",
+			);
+		}
 	}
 	
 	void visit(BreakStatement s) {
@@ -318,6 +329,16 @@ public:
 	void visit(LabeledStatement s) {
 		auto label = s.label;
 		if (label == BuiltinName!"default") {
+			if (switchHaveDefault) {
+				import d.exception;
+				throw new CompileException(
+					s.location,
+					"switch statements with multiple defaults are not allowed.",
+				);
+			}
+			
+			switchHaveDefault = true;
+
 			setCaseEntry(
 				s.location,
 				"Default statement can only appear within switch statement.",

--- a/tests/test0184.d
+++ b/tests/test0184.d
@@ -1,0 +1,19 @@
+//T compiles:no
+//T retval:0
+//T has-passed:yes
+// Tests multiple default in non-final switches
+
+int main() {
+	int x = 10;
+	switch(x) {
+		case 0:
+			return 1;
+		case 2:
+			return 2;
+		default:
+			return 5;
+		default:
+			return 7;
+	}
+}
+

--- a/tests/test0185.d
+++ b/tests/test0185.d
@@ -1,0 +1,32 @@
+//T compiles:yes
+//T retval:0
+//T has-passed:yes
+// Tests nested switch 
+int main() {
+	int x = 10;
+	switch (x) {
+		case 1 :
+			switch (x) {
+				default :
+					break;
+			}
+			break;
+		case 2 :
+			switch (x) {
+				default :
+					break;
+				case 1 :
+					switch (x) {
+						default :
+							break;
+					}
+					break;
+			}
+			break;
+
+		default :
+			break;
+	}
+
+	return 0;
+}

--- a/tests/test0186.d
+++ b/tests/test0186.d
@@ -1,0 +1,21 @@
+//T compiles:no
+//T retval:0
+//T has-passed:yes
+// Tests nested default for no error on missing defaut in non-final switches
+int main() {
+	int x = 10;
+	switch(x) {
+		case 1 :
+			switch (x) {
+				case 1 :
+					break;
+			}
+		case 2 :
+			switch (x) {
+				default :
+					break;
+			}
+		default :
+			break;
+	}
+}

--- a/tests/test0187.d
+++ b/tests/test0187.d
@@ -1,0 +1,15 @@
+//T compiles:no
+//T retval:0
+//T has-passed:yes
+// Tests missing default in non-final switches
+
+int main() {
+	int x = 10;
+	switch(x) {
+		case 0:
+			return 1;
+		case 2:
+			return 2;
+	}
+}
+


### PR DESCRIPTION

This is patch for issue no 192 'no error on missing default in non-final switches'
It check for LabeledStatements with "default" label and sets flag to indicate such statement.
If flag is already set and such statement found it reports error.
No Default statement found then also reports error.
nested cases is also handled.
Changes in file : libd/src/d/semantic/flow.d
New files : tests/test0184.d
            tests/test0185.d
            tests/test0186.d
            tests/test0187.d