### PR TITLE
added DUB configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,17 @@ build.rf
 *.dll
 *.lib
 
+# DUB
+.dub
+dub.selections.json
+
+# IntelliJ
+.idea
+
+# Visual Studio (VisualD)
+*.sln
+.vs
+
 # OSX
 .DS_Store
 

--- a/dub.sdl
+++ b/dub.sdl
@@ -30,7 +30,7 @@ targetPath "bin"
 sourcePaths "sdc"
 importPaths "libd-llvm/src" "libd-llvm/import"
 
-lflags "-L/usr/lib/llvm-3.9/lib" "-Llib" platform="posix"
+lflags "-L/usr/lib/llvm-3.9/lib" platform="posix"
 
 libs "LLVM-3.9" "rt" "dl" "tinfo" "pthread" "z" "m" platform="posix"
 libs "LLVM" platform="windows"

--- a/dub.sdl
+++ b/dub.sdl
@@ -11,11 +11,7 @@ authors "SDC-Developers"
 systemDependencies "LLVM 3.9 development libraries must be available"
 dependency ":libd" version="*"
 dependency ":libd-llvm" version="*"
-
-
-configuration "staticLib" {
-	subConfiguration ":libd" "staticLib"
-}
+subConfiguration ":libd" "staticLib"
 
 targetType "executable"
 targetName "sdc"

--- a/dub.sdl
+++ b/dub.sdl
@@ -15,12 +15,6 @@ dependency ":libd-llvm" version="*"
 
 configuration "staticLib" {
 	subConfiguration ":libd" "staticLib"
-	subConfiguration ":libd-llvm" "staticLib"
-}
-
-configuration "sharedLib" {
-	subConfiguration ":libd" "sharedLib"
-	subConfiguration ":libd-llvm" "sharedLib"
 }
 
 targetType "executable"

--- a/dub.sdl
+++ b/dub.sdl
@@ -1,0 +1,47 @@
+// note: on windows you must build for x86_64 - dub -a x86_64
+
+name "sdc"
+description "The Stupid D Compiler"
+homepage "https://github.com/SDC-Developers/SDC"
+
+license "MIT"
+copyright "Copyright © 2010-2017 SDC-Developers"
+authors "SDC-Developers"
+
+systemDependencies "LLVM 3.9 development libraries must be available"
+dependency ":libd" version="*"
+dependency ":libd-llvm" version="*"
+
+
+configuration "staticLib" {
+	subConfiguration ":libd" "staticLib"
+	subConfiguration ":libd-llvm" "staticLib"
+}
+
+configuration "sharedLib" {
+	subConfiguration ":libd" "sharedLib"
+	subConfiguration ":libd-llvm" "sharedLib"
+}
+
+targetType "executable"
+targetName "sdc"
+targetPath "bin"
+
+sourcePaths "sdc"
+importPaths "libd-llvm/src" "libd-llvm/import"
+
+lflags "-L/usr/lib/llvm-3.9/lib" "-Llib" platform="posix"
+
+libs "LLVM-3.9" "rt" "dl" "tinfo" "pthread" "z" "m" platform="posix"
+libs "LLVM" platform="windows"
+
+buildType "debug" {
+        buildOptions "debugMode" "debugInfo" "warnings" "deprecationWarnings" "warningsAsErrors" "unittests"
+}
+
+buildType "release" {
+        buildOptions "releaseMode" "optimize" "warnings" "deprecationWarnings" "warningsAsErrors"
+}
+
+subPackage "libd"
+subPackage "libd-llvm"

--- a/libd-llvm/dub.sdl
+++ b/libd-llvm/dub.sdl
@@ -1,13 +1,12 @@
-name "libd"
-description "SDC D parser library"
-homepage "https://github.com/SDC-Developers/SDC"
-
-license "MIT"
-copyright "Copyright © 2010-2017 SDC-Developers"
-authors "SDC-Developers"
-
-targetName "d"
+name "libd-llvm"
+targetName "d-llvm"
 targetPath "../lib"
+
+sourcePaths "src" "import"
+importPaths "../libd/src"
+
+// these files are yet "not ready" for D or doesn't needed at all ?
+excludedSourceFiles "*/errorHandling.d" "*/lto.d"	
 
 configuration "sharedLib" {
    # note - on windows for link dll there is this needed - https://github.com/dlang/druntime/blob/master/src/core/sys/windows/dll.d#L473

--- a/libd-llvm/dub.sdl
+++ b/libd-llvm/dub.sdl
@@ -1,19 +1,10 @@
 name "libd-llvm"
 targetName "d-llvm"
+targetType "library"
 targetPath "../lib"
 
 sourcePaths "src" "import"
-importPaths "../libd/src"
+importPaths "../libd/src" ".."
 
 // these files are yet "not ready" for D or doesn't needed at all ?
 excludedSourceFiles "*/errorHandling.d" "*/lto.d"	
-
-configuration "sharedLib" {
-   # note - on windows for link dll there is this needed - https://github.com/dlang/druntime/blob/master/src/core/sys/windows/dll.d#L473
-   targetType "dynamicLibrary"
-   versions "WindowsDLL" platform="windows"
-}
-
-configuration "staticLib" {
-   targetType "library"
-}

--- a/libd-llvm/src/dllmain.d
+++ b/libd-llvm/src/dllmain.d
@@ -1,4 +1,0 @@
-version (WindowsDLL) {
-  import core.sys.windows.dll;
-  mixin SimpleDllMain;
-}

--- a/libd-llvm/src/dllmain.d
+++ b/libd-llvm/src/dllmain.d
@@ -1,0 +1,4 @@
+version (WindowsDLL) {
+  import core.sys.windows.dll;
+  mixin SimpleDllMain;
+}

--- a/libd/dub.sdl
+++ b/libd/dub.sdl
@@ -1,0 +1,21 @@
+// note: on windows you must build for x86_64 - dub --arch=x86_64
+
+name "libd"
+description "SDC D parser library"
+homepage "https://github.com/SDC-Developers/SDC"
+
+license "MIT"
+copyright ""
+authors "Amaury Séchet"
+
+targetType "library"
+//targetType  "dynamicLibrary"
+targetName "libd"
+
+buildType "debug" {
+        buildOptions "debugMode" "debugInfo" "warnings" "deprecationWarnings" "warningsAsErrors" "unittests"
+}
+
+buildType "release" {
+        buildOptions "releaseMode" "optimize" "warnings" "deprecationWarnings" "warningsAsErrors"
+}

--- a/libd/src/d/lexer.d
+++ b/libd/src/d/lexer.d
@@ -293,7 +293,7 @@ private:
 						break;
 					
 					default :
-						assert(0, "Unrecheable.");
+						assert(0, "Unreachable.");
 				}
 			}
 		} else {

--- a/libd/src/dllmain.d
+++ b/libd/src/dllmain.d
@@ -1,0 +1,4 @@
+version (WindowsDLL) {
+  import core.sys.windows.dll;
+  mixin SimpleDllMain;
+}

--- a/libd/src/util/terminal.d
+++ b/libd/src/util/terminal.d
@@ -5,7 +5,7 @@ import std.stdio;
 import d.context.location;
 
 version(Windows) {
-	import std.c.windows.windows;
+	import core.sys.windows.windows;
 }
 
 void outputCaretDiagnostics(FullLocation loc, string fixHint) {


### PR DESCRIPTION
It works flawlessly under **Linux** (tested on Ubuntu with LLVM 3.9.1)

On **Windows** building libd library works for shared and static library.
Building the libd-llvm static lib works. Building the libd-llvm DLL and SDC fails because of linking against LLVM lib doesn't work and i can't figure out whats wrong.
