### PR TITLE
Ensure GCC choice is respected by sdc.mak makefile

### DIFF
--- a/src/sdc.mak
+++ b/src/sdc.mak
@@ -28,7 +28,7 @@ obj/driver/%.o: src/driver/%.d $(LIBD_SRC) $(LIBD_LLVM_SRC)
 
 bin/%: obj/driver/%.o $(LIBSDC) $(LIBD) $(LIBD_LLVM)
 	@mkdir -p bin
-	gcc -o $@ $< $(ARCHFLAG) $(LDFLAGS)
+	$(GCC) -o $@ $< $(ARCHFLAG) $(LDFLAGS)
 
 bin/sdc.conf:
 	@mkdir -p bin


### PR DESCRIPTION
This is the only place in any of the makefiles where `gcc` was invoked directly, so this tweak should ensure that when the user tries to build with `make GCC=...` their choice will indeed be used.