### PR TITLE
Fix errors on Travis-CI.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,10 @@ language: d
 # Use container based infrastructure.
 sudo: false
 
+d:
+  - dmd
+  - dmd-2.072.2
+
 matrix:
   include:
     - os: linux

--- a/src/sdc/util/json.d
+++ b/src/sdc/util/json.d
@@ -92,7 +92,7 @@ import std.array;
 import std.algorithm;
 import std.string;
 import std.uni;
-import std.utf : toUTF8;
+import std.utf : encode;
 import std.stdio;
 import std.math;
 
@@ -2137,7 +2137,8 @@ private struct JSONReader(InputRange) {
 
                     char[4] buf;
 
-                    result.put(toUTF8(buf, val));
+                    const sz = encode!(Yes.useReplacementDchar)(buf, val);
+                    result.put(buf[0 .. sz]);
                 break;
                 default:
                     throw complaint("Invalid escape character");


### PR DESCRIPTION
The function std.utf.toUTF8() was removed with DMD 2.077.0. This
commit replaces the call with  std.utf.endcode(), which is also
backwards compatible.