### PR TITLE
[WIP] Implement FreeBSD support.

### DIFF
--- a/makefile
+++ b/makefile
@@ -37,6 +37,10 @@ ifeq ($(PLATFORM),Darwin)
 	override LDFLAGS += -lc++
 	override NASMFLAGS += -f macho64
 endif
+ifeq ($(PLATFORM),FreeBSD)
+	override LDFLAGS += -lc++
+	override NASMFLAGS += -f elf64
+endif
 
 SDLIB_DEPS = $(SDC) bin/sdc.conf
 

--- a/sdlib/d/gc/mman.d
+++ b/sdlib/d/gc/mman.d
@@ -107,6 +107,14 @@ version(OSX) {
 		Anon	  = 0x1000,
 	}
 }
+version(FreeBSD) {
+	enum Map {
+		Shared	= 0x01,
+		Private	= 0x02,
+		Fixed	  = 0x10,
+		Anon	  = 0x1000,
+	}
+}
 version(linux) {
 	enum Map {
 		Shared	= 0x01,

--- a/sdlib/d/rt/thread.d
+++ b/sdlib/d/rt/thread.d
@@ -77,6 +77,23 @@ version(OSX) {
 	}
 }
 
+version(FreeBSD) {
+	void* getStackBottom() {
+		pthread_attr_t attr;
+		void* addr;	size_t size;
+
+		pthread_attr_init(&attr);
+		pthread_attr_get_np(pthread_self(),	&attr);
+		pthread_attr_getstack(&attr, &addr,	&size);
+		pthread_attr_destroy(&attr);
+		return addr	+ size;
+	}
+
+	void registerTlsSegments() {
+		// TODO
+	}
+}
+
 // XXX: Will do for now.
 alias pthread_t = size_t;
 union pthread_attr_t {
@@ -96,6 +113,13 @@ version(linux) {
 
 version(OSX) {
 	void* pthread_get_stackaddr_np(pthread_t __th);
+}
+
+version(FreeBSD) {
+	int pthread_attr_init(pthread_attr_t*);
+	int pthread_attr_get_np(pthread_t, pthread_attr_t *);
+	int pthread_attr_getstack(pthread_attr_t*, void**, size_t*);
+	int pthread_attr_destroy(pthread_attr_t*);
 }
 
 void _tl_gc_set_stack_bottom(const void* bottom);

--- a/src/d/context/name.d
+++ b/src/d/context/name.d
@@ -125,7 +125,7 @@ enum Prefill = [
 	// Linkages
 	"C", "D", "C++", "Windows", "System", "Pascal", "Java",
 	// Version
-	"SDC", "D_LP64", "X86_64", "linux", "OSX", "Posix",
+	"SDC", "D_LP64", "X86_64", "linux", "OSX", "FreeBSD", "Posix",
 	// Generated
 	"init", "length", "max", "min", "ptr", "sizeof", "alignof",
 	// Scope

--- a/src/d/llvm/backend.d
+++ b/src/d/llvm/backend.d
@@ -37,6 +37,8 @@ public:
 		
 		version(OSX) {
 			auto triple = "x86_64-apple-darwin9".ptr;
+		} else version (FreeBSD) {
+			auto triple = "x86_64-unknown-freebsd".ptr;
 		} else {
 			auto triple = "x86_64-pc-linux-gnu".ptr;
 		}

--- a/src/d/semantic/semantic.d
+++ b/src/d/semantic/semantic.d
@@ -178,6 +178,10 @@ auto getDefaultVersions() {
 		versions ~=  BuiltinName!"OSX";
 	}
 	
+	version(FreeBSD) {
+		versions ~=  BuiltinName!"FreeBSD";
+	}
+
 	version(Posix) {
 		versions ~=  BuiltinName!"Posix";
 	}


### PR DESCRIPTION
FreeBSD support on x86_64 is easy to add because it is already
supported by the other D compilers.