### PR TITLE
Remove the unittest flag from build because SDC won't run if it's there

### DIFF
--- a/makefile
+++ b/makefile
@@ -2,7 +2,7 @@ DMD ?= dmd
 GCC ?= gcc
 NASM ?= nasm
 ARCHFLAG ?= -m64
-DFLAGS = $(ARCHFLAG) -w -debug -g -unittest
+DFLAGS = $(ARCHFLAG) -w -debug -g
 PLATFORM = $(shell uname -s)
 
 # DFLAGS = $(ARCHFLAG) -w -O -release


### PR DESCRIPTION
somehow sdc will just quit after running the unitttests when it's compiled with -unittest.
